### PR TITLE
#13 Implement relationship migration

### DIFF
--- a/.env
+++ b/.env
@@ -9,4 +9,4 @@ NEO4J_DATABASE=testneo4j
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=password
 
-XML_CONFIG_LOCATION=src/main/resources/xml/node-script.xml
+XML_CONFIG_LOCATION=src/main/resources/xml/relationship-script.xml

--- a/.env
+++ b/.env
@@ -9,4 +9,4 @@ NEO4J_DATABASE=testneo4j
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=password
 
-XML_CONFIG_LOCATION=src/main/resources/xml/relationship-script.xml
+XML_CONFIG_LOCATION=src/main/resources/xml/node-script.xml

--- a/.env
+++ b/.env
@@ -9,4 +9,4 @@ NEO4J_DATABASE=testneo4j
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=password
 
-XML_CONFIG_LOCATION=src/main/resources/xml/script.xml
+XML_CONFIG_LOCATION=src/main/resources/xml/relationship-script.xml

--- a/README.md
+++ b/README.md
@@ -78,21 +78,26 @@ creation.
 2) `<tables>` - collection of tables to be migrated.
 3) `<table>` - table tag, defines table name in `name` attribute, its
    configuration and labels.
-4) `<configuration>` - configuration for columns.
-5) `<excludedColumns>` - columns to be excluded from migration. It means after
+4) `<configuration>` - (optional for `node` migration mode) configuration for
+   columns.
+5) `<excludedColumns>` - (optional) columns to be excluded from migration. It
+   means after
    migration in Neo4j no data from these columns will be stored.
 6) `<column>` - column tag, contains table name.
-7) `<renamedColumns>` - columns to be renamed during migration. It means data
+7) `<renamedColumns>` - (optional) columns to be renamed during migration. It
+   means data
    from column with `<previousName>`
    will be stored as `<newName>` property;
-8) `<labels>` - collection of labels to be added to Nodes.
+8) `<labels>` - (optional) collection of labels to be added to Nodes.
 9) `<label>` - label tag, defines its name.
 10) `<columnFrom>` - column with foreign key to entity table. Relationship will
     be started from Node from that table by this foreign key.
 11) `<columnTo>` - column with foreign key to entity table. Relationship will
     be ended with Node from that table by this foreign key.
-12) `<labelFrom>` - specifies label of start node to find it by foreign key.
-12) `<labelTo>` - specifies label of end node to find it by foreign key.
+12) `<labelFrom>` - (optional) specifies label of start node to find it by
+    foreign key.
+12) `<labelTo>` - (optional) specifies label of end node to find it by foreign
+    key.
 13) `<type>` - type of the relationship.
 
 ### NOTE
@@ -101,12 +106,16 @@ You can safely omit `<labels>` and / or `<configuration>` tags for node
 migration - then all
 columns will be migrated and no labels will be added to generated nodes.
 
-If you want to migrate relationships, you need to add labels to your migrated
-nodes. This restriction may be changed in the future.
+If you want to migrate relationships, you need to add labels to ensure type of
+nodes to be connected. You can omit this tag if you sure that all of your nodes
+have unique id.
 
 Note that at first we exclude columns and only after rename them. So if you will
 rename excluded columns, it was excluded and no columns with this name will be
 renamed.
+
+We recommend to provide all available fields to be sure that correct data will
+be saved to Neo4j.
 
 ### How it works?
 
@@ -117,6 +126,10 @@ After it, these files are read and uploaded to Neo4j.
 
 These migration files are not deleted after script execution. So you can see
 what data was dumped and uploaded to Neo4j.
+
+Relationship migration is provided by matching nodes with provided primary key.
+So if some of your nodes have similar id, relationship will be added to each of
+them. It can be avoided but providing `<labelFrom>` and `<labelTo>` tags.
 
 If no exceptions were thrown, you will see messages in logs with amount of
 created nodes.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ User can:
 - choose what columns from table to migrate
 - rename columns
 - add labels to generated nodes
+- migrate relationships by migrating foreign keys
 
 Future features:
 
-- add relationships
 - time and boolean formatting
 
 ### How to use?
@@ -24,7 +24,8 @@ Future features:
 
 ### Markup example
 
-Here is an example of XML configuration file.
+Here is an example of XML configuration file for node creation and relationship
+creation.
 
 ```
 <migration type="node">
@@ -46,31 +47,66 @@ Here is an example of XML configuration file.
                 <label>BaseEntity</label>
             </labels>
         </table>
-        <table name="tasks"/>
+        <table name="tasks">
+            <labels>
+                <label>Task</label>
+                <label>BaseEntity</label>
+            </labels>
+        </table>
     </tables>
 </migration>
 ```
 
-Tags:
+```
+<migration type="relationship">
+    <tables>
+        <table name="users_tasks">
+            <configuration>
+                <columnFrom>user_id</columnFrom>
+                <labelFrom>User</labelFrom>
+                <columnTo>task_id</columnTo>
+                <labelTo>Task</labelTo>
+            </configuration>
+            <type>HAS_TASK</label>
+        </table>
+    </tables>
+</migration>
+```
 
 1) `<migration>` - main tag, defines whether Node or Relationship is going to be
-   created. You need to provide `type` attribute - `node`.
+   created. You need to provide `type` attribute - `node` or `relationship`.
 2) `<tables>` - collection of tables to be migrated.
 3) `<table>` - table tag, defines table name in `name` attribute, its
    configuration and labels.
 4) `<configuration>` - configuration for columns.
 5) `<excludedColumns>` - columns to be excluded from migration. It means after
-   migration in
-   Neo4j no data from these columns will be stored.
+   migration in Neo4j no data from these columns will be stored.
 6) `<column>` - column tag, contains table name.
 7) `<renamedColumns>` - columns to be renamed during migration. It means data
    from column with `<previousName>`
    will be stored as `<newName>` property;
 8) `<labels>` - collection of labels to be added to Nodes.
 9) `<label>` - label tag, defines its name.
+10) `<columnFrom>` - column with foreign key to entity table. Relationship will
+    be started from Node from that table by this foreign key.
+11) `<columnTo>` - column with foreign key to entity table. Relationship will
+    be ended with Node from that table by this foreign key.
+12) `<labelFrom>` - specifies label of start node to find it by foreign key.
+12) `<labelTo>` - specifies label of end node to find it by foreign key.
+13) `<type>` - type of the relationship.
 
-You can safely omit `<labels>` and / or `<configuration>` tags - then all
+### NOTE
+
+You can safely omit `<labels>` and / or `<configuration>` tags for node
+migration - then all
 columns will be migrated and no labels will be added to generated nodes.
+
+If you want to migrate relationships, you need to add labels to your migrated
+nodes. This restriction may be changed in the future.
+
+Note that at first we exclude columns and only after rename them. So if you will
+rename excluded columns, it was excluded and no columns with this name will be
+renamed.
 
 ### How it works?
 
@@ -81,10 +117,6 @@ After it, these files are read and uploaded to Neo4j.
 
 These migration files are not deleted after script execution. So you can see
 what data was dumped and uploaded to Neo4j.
-
-Note that at first we exclude columns and only after rename them. So if you will
-rename excluded columns, it was excluded and no columns with this name will be
-renamed.
 
 If no exceptions were thrown, you will see messages in logs with amount of
 created nodes.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Future features:
 
 ### Markup example
 
-Here is an example of XML configuration file for node creation and relationship
-creation.
+Here is an example of XML configuration file for node and relationship
+migration.
 
 ```
 <migration type="node">

--- a/src/main/java/com/example/postgresneo4jmigrationtool/PostgresNeo4jMigrationToolApplication.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/PostgresNeo4jMigrationToolApplication.java
@@ -13,7 +13,7 @@ public class PostgresNeo4jMigrationToolApplication {
     public static void main(String[] args) {
         ConfigurableApplicationContext appContext = SpringApplication.run(PostgresNeo4jMigrationToolApplication.class, args);
         Parser parser = appContext.getBean(Parser.class);
-        parser.run();
+        parser.parse();
     }
 
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/config/ApplicationConfig.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/config/ApplicationConfig.java
@@ -8,18 +8,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.File;
-import java.util.Scanner;
 
 @Configuration
 public class ApplicationConfig {
 
     @Value("${xml.script.path}")
     private String xmlPath;
-
-    @Bean
-    public Scanner scanner() {
-        return new Scanner(System.in).useDelimiter("\n");
-    }
 
     @SneakyThrows
     @Bean

--- a/src/main/java/com/example/postgresneo4jmigrationtool/generator/dumper/CSVPostgresDumper.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/generator/dumper/CSVPostgresDumper.java
@@ -10,6 +10,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.util.Collection;
 import java.util.Map;
 
 @Service
@@ -19,43 +20,25 @@ public class CSVPostgresDumper implements PostgresDumper {
     private final PostgresRepository postgresRepository;
     private final String dumpDirectory = "dump";
     private final String dumpScriptFileName = "dump_script.sh";
-    private final String delimeter = ";";
+    private final String delimiter = ";";
 
     @Override
-    public DumpResult dump(String tableName, Map<String, String> columnsInfo) {
+    public DumpResult dump(String tableName, Collection<String> columnsInfo) {
         DumpResult dumpResult = new DumpResult();
         dumpResult.add("dumpDirectory", dumpDirectory);
-        dumpResult.add("delimeter", delimeter);
-
+        dumpResult.add("delimiter", delimiter);
         File dumpScript = new File(dumpDirectory + "/" + dumpScriptFileName);
         createFile(dumpScript);
-        String columns = String.join(",", columnsInfo.keySet());
+        String columns = String.join(",", columnsInfo);
         try (PrintWriter writer = new PrintWriter(dumpScript)) {
             writer.printf("psql -U %s -c \"COPY (SELECT %s FROM %s) TO STDOUT WITH CSV DELIMITER '%s' HEADER\" %s > %s.csv",
-                    postgresRepository.getUsername(), columns, tableName, delimeter,
+                    postgresRepository.getUsername(), columns, tableName, delimiter,
                     postgresRepository.getDatabaseName(), tableName);
         } catch (Exception e) {
             throw new IllegalStateException("Exception during dumping: " + e.getMessage());
         }
-
-        try {
-            ProcessBuilder processBuilder = new ProcessBuilder("/bin/bash", dumpScript.getAbsolutePath());
-            Map<String, String> env = processBuilder.environment();
-            env.put("PGPASSWORD", postgresRepository.getPassword());
-            processBuilder.directory(new File(dumpScript.getParent()));
-            Process process = processBuilder.start();
-            process.waitFor();
-        } catch (Exception e) {
-            throw new IllegalStateException("Exception during dumping: " + e.getMessage());
-        }
-
-        try {
-            InputStream inputStream = new FileInputStream(dumpDirectory + "/" + tableName + ".csv");
-            dumpResult.add("inputStream", inputStream);
-        } catch (FileNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-
+        runScript(dumpScript);
+        addInputStream(dumpResult, tableName);
         return dumpResult;
     }
 
@@ -63,20 +46,30 @@ public class CSVPostgresDumper implements PostgresDumper {
     public DumpResult dumpWithForeignKeys(String tableName, String columnFrom, String columnTo) {
         DumpResult dumpResult = new DumpResult();
         dumpResult.add("dumpDirectory", dumpDirectory);
-        dumpResult.add("delimeter", delimeter);
-
+        dumpResult.add("delimiter", delimiter);
         File dumpScript = new File(dumpDirectory + "/" + dumpScriptFileName);
         createFile(dumpScript);
         String foreignColumnFrom = postgresRepository.getForeignColumnName(tableName, columnFrom);
         String foreignColumnTo = postgresRepository.getForeignColumnName(tableName, columnTo);
         try (PrintWriter writer = new PrintWriter(dumpScript)) {
             writer.printf("psql -U %s -c \"COPY (SELECT %s as %s, %s as %s FROM %s) TO STDOUT WITH CSV DELIMITER '%s' HEADER\" %s > %s.csv",
-                    postgresRepository.getUsername(), columnFrom, foreignColumnFrom, columnTo, foreignColumnTo, tableName, delimeter,
+                    postgresRepository.getUsername(), columnFrom, foreignColumnFrom, columnTo, foreignColumnTo, tableName, delimiter,
                     postgresRepository.getDatabaseName(), tableName);
         } catch (Exception e) {
             throw new IllegalStateException("Exception during dumping: " + e.getMessage());
         }
+        runScript(dumpScript);
+        addInputStream(dumpResult, tableName);
+        return dumpResult;
+    }
 
+    private void createFile(File file) {
+        if (!file.exists()) {
+            file.getParentFile().mkdirs();
+        }
+    }
+
+    private void runScript(File dumpScript) {
         try {
             ProcessBuilder processBuilder = new ProcessBuilder("/bin/bash", dumpScript.getAbsolutePath());
             Map<String, String> env = processBuilder.environment();
@@ -87,20 +80,14 @@ public class CSVPostgresDumper implements PostgresDumper {
         } catch (Exception e) {
             throw new IllegalStateException("Exception during dumping: " + e.getMessage());
         }
+    }
 
+    private void addInputStream(DumpResult dumpResult, String tableName) {
         try {
             InputStream inputStream = new FileInputStream(dumpDirectory + "/" + tableName + ".csv");
             dumpResult.add("inputStream", inputStream);
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
-        }
-
-        return dumpResult;
-    }
-
-    private void createFile(File file) {
-        if (!file.exists()) {
-            file.getParentFile().mkdirs();
         }
     }
 

--- a/src/main/java/com/example/postgresneo4jmigrationtool/generator/dumper/CSVPostgresDumper.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/generator/dumper/CSVPostgresDumper.java
@@ -59,6 +59,45 @@ public class CSVPostgresDumper implements PostgresDumper {
         return dumpResult;
     }
 
+    @Override
+    public DumpResult dumpWithForeignKeys(String tableName, String columnFrom, String columnTo) {
+        DumpResult dumpResult = new DumpResult();
+        dumpResult.add("dumpDirectory", dumpDirectory);
+        dumpResult.add("delimeter", delimeter);
+
+        File dumpScript = new File(dumpDirectory + "/" + dumpScriptFileName);
+        createFile(dumpScript);
+        String foreignColumnFrom = postgresRepository.getForeignColumnName(tableName, columnFrom);
+        String foreignColumnTo = postgresRepository.getForeignColumnName(tableName, columnTo);
+        try (PrintWriter writer = new PrintWriter(dumpScript)) {
+            writer.printf("psql -U %s -c \"COPY (SELECT %s as %s, %s as %s FROM %s) TO STDOUT WITH CSV DELIMITER '%s' HEADER\" %s > %s.csv",
+                    postgresRepository.getUsername(), columnFrom, foreignColumnFrom, columnTo, foreignColumnTo, tableName, delimeter,
+                    postgresRepository.getDatabaseName(), tableName);
+        } catch (Exception e) {
+            throw new IllegalStateException("Exception during dumping: " + e.getMessage());
+        }
+
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder("/bin/bash", dumpScript.getAbsolutePath());
+            Map<String, String> env = processBuilder.environment();
+            env.put("PGPASSWORD", postgresRepository.getPassword());
+            processBuilder.directory(new File(dumpScript.getParent()));
+            Process process = processBuilder.start();
+            process.waitFor();
+        } catch (Exception e) {
+            throw new IllegalStateException("Exception during dumping: " + e.getMessage());
+        }
+
+        try {
+            InputStream inputStream = new FileInputStream(dumpDirectory + "/" + tableName + ".csv");
+            dumpResult.add("inputStream", inputStream);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
+        return dumpResult;
+    }
+
     private void createFile(File file) {
         if (!file.exists()) {
             file.getParentFile().mkdirs();

--- a/src/main/java/com/example/postgresneo4jmigrationtool/generator/dumper/PostgresDumper.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/generator/dumper/PostgresDumper.java
@@ -8,4 +8,6 @@ public interface PostgresDumper {
 
     DumpResult dump(String tableName, Map<String, String> columnsInfo);
 
+    DumpResult dumpWithForeignKeys(String tableName, String columnFrom, String columnTo);
+
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/generator/dumper/PostgresDumper.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/generator/dumper/PostgresDumper.java
@@ -2,11 +2,11 @@ package com.example.postgresneo4jmigrationtool.generator.dumper;
 
 import com.example.postgresneo4jmigrationtool.model.DumpResult;
 
-import java.util.Map;
+import java.util.Collection;
 
 public interface PostgresDumper {
 
-    DumpResult dump(String tableName, Map<String, String> columnsInfo);
+    DumpResult dump(String tableName, Collection<String> columnsToDump);
 
     DumpResult dumpWithForeignKeys(String tableName, String columnFrom, String columnTo);
 

--- a/src/main/java/com/example/postgresneo4jmigrationtool/generator/uploader/CSVNeo4jUploader.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/generator/uploader/CSVNeo4jUploader.java
@@ -20,14 +20,13 @@ public class CSVNeo4jUploader implements Neo4jUploader {
     private final Neo4jRepository neo4jRepository;
 
     @Override
-    public UploadResult uploadNode(InputStream inputStream, UploadParams params) {
+    public UploadResult createNode(InputStream inputStream, UploadParams params) {
         UploadResult uploadResult = new UploadResult();
         try (Scanner scanner = new Scanner(inputStream)) {
             String headers = scanner.nextLine();
-            String[] columnNames = headers.split(String.valueOf(params.get("delimeter")));
-            String datePattern = (String) params.get("datePattern");
-            Map<String, String> newNames = (Map<String, String>) params.get("newNames");
+            String[] columnNames = headers.split(String.valueOf(params.get("delimiter")));
             List<String> labels = (List<String>) params.get("labels");
+            Map<String, String> newNames = (Map<String, String>) params.get("newNames");
             for (int i = 0; i < columnNames.length; i++) {
                 if (newNames.containsKey(columnNames[i])) {
                     columnNames[i] = newNames.get(columnNames[i]);
@@ -36,7 +35,7 @@ public class CSVNeo4jUploader implements Neo4jUploader {
             int nodeCounter = 0;
             while (scanner.hasNextLine()) {
                 String data = scanner.nextLine();
-                String[] values = data.split(String.valueOf(params.get("delimeter")));
+                String[] values = data.split(String.valueOf(params.get("delimiter")));
                 Node node = new Node(columnNames, values);
                 neo4jRepository.addNode(node, labels.toArray(new String[0]));
                 nodeCounter++;
@@ -47,18 +46,18 @@ public class CSVNeo4jUploader implements Neo4jUploader {
     }
 
     @Override
-    public UploadResult uploadRelationship(InputStream inputStream, UploadParams params) {
+    public UploadResult createRelationship(InputStream inputStream, UploadParams params) {
         UploadResult uploadResult = new UploadResult();
         try (Scanner scanner = new Scanner(inputStream)) {
             String headers = scanner.nextLine();
-            String[] columnNames = headers.split(String.valueOf(params.get("delimeter")));
+            String[] columnNames = headers.split(String.valueOf(params.get("delimiter")));
             String type = (String) params.get("type");
             String labelFrom = (String) params.get("labelFrom");
             String labelTo = (String) params.get("labelTo");
             int relationshipCounter = 0;
             while (scanner.hasNextLine()) {
                 String data = scanner.nextLine();
-                String[] values = data.split(String.valueOf(params.get("delimeter")));
+                String[] values = data.split(String.valueOf(params.get("delimiter")));
                 Node nodeFrom = new Node(new String[]{columnNames[0]}, new String[]{values[0]});
                 Node nodeTo = new Node(new String[]{columnNames[1]}, new String[]{values[1]});
                 Relationship relationship = new Relationship(nodeFrom, nodeTo, labelFrom, labelTo);
@@ -69,4 +68,5 @@ public class CSVNeo4jUploader implements Neo4jUploader {
         }
         return uploadResult;
     }
+
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/generator/uploader/Neo4jUploader.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/generator/uploader/Neo4jUploader.java
@@ -7,8 +7,8 @@ import java.io.InputStream;
 
 public interface Neo4jUploader {
 
-    UploadResult uploadNode(InputStream inputStream, UploadParams params);
+    UploadResult createNode(InputStream inputStream, UploadParams params);
 
-    UploadResult uploadRelationship(InputStream inputStream, UploadParams params);
+    UploadResult createRelationship(InputStream inputStream, UploadParams params);
 
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/generator/uploader/Neo4jUploader.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/generator/uploader/Neo4jUploader.java
@@ -7,6 +7,8 @@ import java.io.InputStream;
 
 public interface Neo4jUploader {
 
-    UploadResult upload(InputStream inputStream, UploadParams params);
+    UploadResult uploadNode(InputStream inputStream, UploadParams params);
+
+    UploadResult uploadRelationship(InputStream inputStream, UploadParams params);
 
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/model/Node.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/model/Node.java
@@ -10,11 +10,11 @@ public class Node {
     private String[] names;
     private Object[] values;
 
-    public String getDataString() {
+    @Override
+    public String toString() {
         StringBuilder result = new StringBuilder("{");
         for (int i = 0; i < names.length; i++) {
             result.append(names[i]).append(": ");
-            //TODO handle multiple types
             if (values[i] instanceof String) {
                 result.append("\"");
                 result.append(values[i]);

--- a/src/main/java/com/example/postgresneo4jmigrationtool/model/Relationship.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/model/Relationship.java
@@ -1,0 +1,15 @@
+package com.example.postgresneo4jmigrationtool.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Relationship {
+
+    private Node nodeFrom;
+    private Node nodeTo;
+    private String labelFrom;
+    private String labelTo;
+
+}

--- a/src/main/java/com/example/postgresneo4jmigrationtool/parser/Parser.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/parser/Parser.java
@@ -2,6 +2,6 @@ package com.example.postgresneo4jmigrationtool.parser;
 
 public interface Parser {
 
-    void run();
+    void parse();
 
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/parser/XmlParser.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/parser/XmlParser.java
@@ -69,7 +69,9 @@ public class XmlParser implements Parser {
     }
 
     private void parseRelationshipMigration(XML root) {
-        List<XML> tables = root.nodes("tables").get(0).nodes("table");
+        List<XML> tables = root.nodes("tables")
+                .get(0)
+                .nodes("table");
         for (XML table : tables) {
             String tableName = getTableName(table);
             String columnFrom = getConfigurationTagValue(table, "columnFrom");
@@ -144,12 +146,17 @@ public class XmlParser implements Parser {
     }
 
     private String getConfigurationTagValue(XML table, String tag) {
-        return table.nodes("configuration")
+        List<XML> tags = table.nodes("configuration")
                 .get(0)
-                .nodes(tag)
-                .get(0)
-                .xpath("text()")
-                .get(0);
+                .nodes(tag);
+        if (!tags.isEmpty()) {
+            return tags
+                    .get(0)
+                    .xpath("text()")
+                    .get(0);
+        } else {
+            return "";
+        }
     }
 
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/repository/neo4j/Neo4jRepository.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/repository/neo4j/Neo4jRepository.java
@@ -1,13 +1,12 @@
 package com.example.postgresneo4jmigrationtool.repository.neo4j;
 
 import com.example.postgresneo4jmigrationtool.model.Node;
-
-import java.util.Map;
+import com.example.postgresneo4jmigrationtool.model.Relationship;
 
 public interface Neo4jRepository {
 
     void addNode(Node node, String... labels);
 
-    void addRelationship(Object fromNodeId, Object toNodeId, Map<String, Object> data, String label);
+    void addRelationship(Relationship relationship, String type);
 
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/repository/neo4j/Neo4jRepositoryImpl.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/repository/neo4j/Neo4jRepositoryImpl.java
@@ -29,7 +29,13 @@ public class Neo4jRepositoryImpl implements Neo4jRepository {
     @Override
     @Transactional
     public void addRelationship(Relationship relationship, String type) {
-        String query = "MATCH(nodeFrom: %s {%s: '%s'}) MATCH(nodeTo: %s {%s: '%s'}) CREATE (nodeFrom)-[:%s]->(nodeTo)";
+        String query = "MATCH(nodeFrom %s {%s: '%s'}) MATCH(nodeTo %s {%s: '%s'}) CREATE (nodeFrom)-[:%s]->(nodeTo)";
+        if (!relationship.getLabelFrom().isEmpty()) {
+            relationship.setLabelFrom(": " + relationship.getLabelFrom());
+        }
+        if (!relationship.getLabelTo().isEmpty()) {
+            relationship.setLabelTo(": " + relationship.getLabelTo());
+        }
         String preparedQuery = String.format(query,
                 relationship.getLabelFrom(),
                 relationship.getNodeFrom().getNames()[0],

--- a/src/main/java/com/example/postgresneo4jmigrationtool/repository/neo4j/Neo4jRepositoryImpl.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/repository/neo4j/Neo4jRepositoryImpl.java
@@ -1,12 +1,11 @@
 package com.example.postgresneo4jmigrationtool.repository.neo4j;
 
 import com.example.postgresneo4jmigrationtool.model.Node;
+import com.example.postgresneo4jmigrationtool.model.Relationship;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.neo4j.core.Neo4jClient;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Map;
 
 @Repository
 @RequiredArgsConstructor
@@ -29,8 +28,17 @@ public class Neo4jRepositoryImpl implements Neo4jRepository {
 
     @Override
     @Transactional
-    public void addRelationship(Object fromNodeId, Object toNodeId, Map<String, Object> data, String label) {
-
+    public void addRelationship(Relationship relationship, String type) {
+        String query = "MATCH(nodeFrom: %s {%s: '%s'}) MATCH(nodeTo: %s {%s: '%s'}) CREATE (nodeFrom)-[:%s]->(nodeTo)";
+        String preparedQuery = String.format(query,
+                relationship.getLabelFrom(),
+                relationship.getNodeFrom().getNames()[0],
+                relationship.getNodeFrom().getValues()[0],
+                relationship.getLabelTo(),
+                relationship.getNodeTo().getNames()[0],
+                relationship.getNodeTo().getValues()[0],
+                type);
+        neo4jClient.query(preparedQuery).fetch().all();
     }
 
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/repository/neo4j/Neo4jRepositoryImpl.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/repository/neo4j/Neo4jRepositoryImpl.java
@@ -17,7 +17,7 @@ public class Neo4jRepositoryImpl implements Neo4jRepository {
     @Transactional
     public void addNode(Node node, String... labels) {
         String query = "CREATE (n %s)";
-        String data = node.getDataString();
+        String data = node.toString();
         String preparedQuery = String.format(query, data);
         if (labels.length > 0) {
             preparedQuery += " SET n :%s";

--- a/src/main/java/com/example/postgresneo4jmigrationtool/repository/postgres/PostgresRepository.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/repository/postgres/PostgresRepository.java
@@ -14,4 +14,6 @@ public interface PostgresRepository {
 
     Map<String, String> getColumnsInfo(String tableName);
 
+    String getForeignColumnName(String tableName, String columnName);
+
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/repository/postgres/PostgresRepositoryImpl.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/repository/postgres/PostgresRepositoryImpl.java
@@ -6,7 +6,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Repository
@@ -37,8 +36,8 @@ public class PostgresRepositoryImpl implements PostgresRepository {
     @Override
     public String getDatabaseName() {
         int beginIndex = datasourceURL.lastIndexOf('/') + 1;
-        int endInder = datasourceURL.indexOf('?');
-        return datasourceURL.substring(beginIndex, endInder);
+        int endIndex = datasourceURL.indexOf('?');
+        return datasourceURL.substring(beginIndex, endIndex);
     }
 
     @Override
@@ -56,39 +55,35 @@ public class PostgresRepositoryImpl implements PostgresRepository {
                 AND table_name   = '%s';
                 """;
         String formattedQuery = String.format(query, getSchemaName(), tableName);
-        List<Map<String, String>> resultList = jdbcTemplate.query(formattedQuery, (rs, rowNum) -> {
+        Map<String, String> columnsInfo = new HashMap<>();
+        jdbcTemplate.query(formattedQuery, (rs, rowNum) -> {
             String columnName = rs.getString("column_name");
             String columnType = rs.getString("data_type");
-            Map<String, String> map = new HashMap<>();
-            map.put(columnName, columnType);
-            return map;
+            columnsInfo.put(columnName, columnType);
+            return columnsInfo;
         });
-        Map<String, String> columnsInfo = new HashMap<>();
-        for (Map<String, String> map : resultList) {
-            columnsInfo.putAll(map);
-        }
         return columnsInfo;
     }
 
     @Override
     public String getForeignColumnName(String tableName, String columnName) {
         String query = """
-                SELECT ccu.table_name  AS foreign_table_name,
-                       ccu.column_name AS foreign_column_name
+                SELECT ccu.column_name AS column_name
                 FROM information_schema.table_constraints AS tc
-                         JOIN information_schema.key_column_usage AS kcu
-                              ON tc.constraint_name = kcu.constraint_name
-                                  AND tc.table_schema = kcu.table_schema
-                         JOIN information_schema.constraint_column_usage AS ccu
-                              ON ccu.constraint_name = tc.constraint_name
-                                  AND ccu.table_schema = tc.table_schema
+                JOIN information_schema.key_column_usage AS kcu
+                ON tc.constraint_name = kcu.constraint_name
+                AND tc.table_schema = kcu.table_schema
+                JOIN information_schema.constraint_column_usage AS ccu
+                ON ccu.constraint_name = tc.constraint_name
+                AND ccu.table_schema = tc.table_schema
                 WHERE tc.constraint_type = 'FOREIGN KEY'
-                  AND tc.table_name = '%s'
-                  AND kcu.column_name = '%s';
+                AND tc.table_name = '%s'
+                AND kcu.column_name = '%s';
                 """;
         String formattedQuery = String.format(query, tableName, columnName);
         return jdbcTemplate.query(formattedQuery, (rs, rowNum) ->
-                        rs.getString("foreign_column_name"))
+                        rs.getString("column_name"))
                 .get(0);
     }
+
 }

--- a/src/main/resources/xml/node-script.xml
+++ b/src/main/resources/xml/node-script.xml
@@ -17,6 +17,11 @@
                 <label>BaseEntity</label>
             </labels>
         </table>
-        <table name="tasks"/>
+        <table name="tasks">
+            <labels>
+                <label>Task</label>
+                <label>BaseEntity</label>
+            </labels>
+        </table>
     </tables>
 </migration>

--- a/src/main/resources/xml/relationship-script.xml
+++ b/src/main/resources/xml/relationship-script.xml
@@ -1,0 +1,13 @@
+<migration type="relationship">
+    <tables>
+        <table name="users_tasks">
+            <configuration>
+                <columnFrom>user_id</columnFrom>
+                <labelFrom>User</labelFrom>
+                <columnTo>task_id</columnTo>
+                <labelTo>Task</labelTo>
+            </configuration>
+            <type>HAS_TASK</type>
+        </table>
+    </tables>
+</migration>


### PR DESCRIPTION
close #13

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the codebase to improve the migration tool between a Postgres database and a Neo4j graph database. Notable changes include renaming `Parser` method, updating XML configuration files, adding `Relationship` and `Node` classes, and modifying several repository and uploader interfaces.

### Detailed summary
- Renamed `Parser` method from `run()` to `parse()`.
- Updated XML configuration files to include `Task` and `BaseEntity` labels.
- Added `Relationship` class to model relationships between nodes.
- Added `Node` class to model nodes.
- Modified several repository and uploader interfaces to use `Relationship` and `Node` objects.
- Modified `PostgresRepository` to include a method to get the foreign column name.
- Modified `CSVNeo4jUploader` to include a method to create relationships based on a CSV file.
- Modified `PostgresDumper` to include a method to dump data with foreign keys and to use a collection instead of a map for columns to dump.
- Added a `toString()` method to `Node` class.

> The following files were skipped due to too many changes: `src/main/java/com/example/postgresneo4jmigrationtool/generator/dumper/CSVPostgresDumper.java`, `README.md`, `src/main/java/com/example/postgresneo4jmigrationtool/parser/XmlParser.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->