### PR TITLE
#12 Implement timestamp and enum types handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,7 @@ User can:
 - rename columns
 - add labels to generated nodes
 - migrate relationships by migrating foreign keys
-
-Future features:
-
-- time and boolean formatting
+- reformat timestamp to time format
 
 ### How to use?
 
@@ -44,6 +41,7 @@ You can validate your schema with `schema.xsd`schema.
                             <newName>newName</newName>
                         </columns>
                     </renamedColumns>
+                    <timeFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timeFormat>
                 </configuration>
                 <labels>
                     <label>User</label>
@@ -90,21 +88,26 @@ You can validate your schema with `schema.xsd`schema.
 9) `<renamedColumns>` - (optional for `node` migration) columns to be renamed
    during migration. It means data from column with `<previousName>`
    will be stored as `<newName>` property;
-10) `<labels>` - (optional for `node` migration) collection of labels to be
+10) `<timeFormat>` - (optional for `node` migration) format of timestamp to
+    store in Neo4j. It is needed to store LocalDateTime and access it without
+    converters in code.
+11) `<labels>` - (optional for `node` migration) collection of labels to be
     added
     to Nodes.
-11) `<label>` - label tag, defines its name.
-12) `<columnFrom>` - column with foreign key to entity table. Relationship will
+12) `<label>` - label tag, defines its name.
+13) `<columnFrom>` - column with foreign key to entity table. Relationship will
     be started from Node from that table by this foreign key.
-13) `<columnTo>` - column with foreign key to entity table. Relationship will
+14) `<columnTo>` - column with foreign key to entity table. Relationship will
     be ended with Node from that table by this foreign key.
-14) `<labelFrom>` - (optional for `migration` mode) specifies label of start
+15) `<labelFrom>` - (optional for `migration` migration) specifies label of
+    start
     node to find it by
     foreign key.
-15) `<labelTo>` - (optional for `migration` mode) specifies label of end node to
+16) `<labelTo>` - (optional for `migration` migration) specifies label of end
+    node to
     find it by foreign
     key.
-16) `<type>` - type of the relationship.
+17) `<type>` - type of the relationship.
 
 ### NOTE
 
@@ -119,6 +122,13 @@ have unique id.
 Note that at first we exclude columns and only after rename them. So if you will
 rename excluded columns, it was excluded and no columns with this name will be
 renamed.
+
+We handle Postgres types in generated JSON the following way:
+
+- `integer`, `bigserial`, `biginteger` are considered numeric values
+- `bool`, `boolean` are considered boolean values
+- `timestamp`, `timestamp without time zone` as timestamp
+- other types - strings.
 
 We recommend to fill up all tags to be sure that correct data will
 be saved to Neo4j.
@@ -136,6 +146,9 @@ what data was dumped and uploaded to Neo4j.
 Relationship migration is provided by matching nodes with provided primary key.
 So if some of your nodes have similar id, relationship will be added to each of
 them. It can be avoided but providing `<labelFrom>` and `<labelTo>` tags.
+
+We parse timestamp from database then format it to provided time format (
+from optional `<timeFormat>` tag).
 
 If no exceptions were thrown, you will see messages in logs with amount of
 created nodes and relationships.

--- a/src/main/java/com/example/postgresneo4jmigrationtool/model/Node.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/model/Node.java
@@ -1,26 +1,69 @@
 package com.example.postgresneo4jmigrationtool.model;
 
-import lombok.AllArgsConstructor;
+import com.example.postgresneo4jmigrationtool.model.exception.InvalidConfigurationException;
 import lombok.Data;
 
+import java.sql.Timestamp;
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+
 @Data
-@AllArgsConstructor
 public class Node {
 
     private String[] names;
     private Object[] values;
+    private String[] types;
+    private String timeFormat;
+
+    public Node(String[] names, Object[] values, String[] types) {
+        this.names = names;
+        this.types = types;
+        this.values = values;
+        if (values.length < types.length) {
+            this.values = Arrays.copyOf(values, values.length + 1);
+        }
+    }
 
     @Override
     public String toString() {
         StringBuilder result = new StringBuilder("{");
         for (int i = 0; i < names.length; i++) {
             result.append(names[i]).append(": ");
-            if (values[i] instanceof String) {
-                result.append("\"");
-                result.append(values[i]);
-                result.append("\"");
-            } else {
-                result.append(values[i]);
+            if (values[i] == null) {
+                break;
+            }
+            switch (types[i]) {
+                case "integer", "bigint", "bigserial" ->
+                        result.append(values[i]);
+                case "boolean", "bool" -> result.append(values[i].equals("t"));
+                case "timestamp", "timestamp without time zone" -> {
+                    result.append("\"");
+                    if (timeFormat == null || timeFormat.isEmpty()) {
+                        result.append(Timestamp.valueOf((String) values[i]));
+                    } else {
+                        try {
+                            Timestamp time = Timestamp.valueOf(values[i].toString());
+                            LocalDateTime localDateTime = time.toLocalDateTime();
+                            OffsetDateTime offsetDateTime = localDateTime.atOffset(ZoneOffset.UTC);
+                            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(timeFormat);
+                            String resultTime = offsetDateTime.format(formatter);
+                            result.append(resultTime);
+                        } catch (IllegalArgumentException |
+                                 DateTimeException e) {
+                            throw new InvalidConfigurationException("Invalid time format configuration: " + e.getMessage());
+                        }
+                    }
+                    result.append("\"");
+                }
+                default -> {
+                    result.append("\"");
+                    result.append(values[i]);
+                    result.append("\"");
+                }
             }
             result.append(", ");
         }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/repository/neo4j/Neo4jRepositoryImpl.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/repository/neo4j/Neo4jRepositoryImpl.java
@@ -29,7 +29,7 @@ public class Neo4jRepositoryImpl implements Neo4jRepository {
     @Override
     @Transactional
     public void addRelationship(Relationship relationship, String type) {
-        String query = "MATCH(nodeFrom %s {%s: '%s'}) MATCH(nodeTo %s {%s: '%s'}) CREATE (nodeFrom)-[:%s]->(nodeTo)";
+        String query = "MATCH(nodeFrom %s %s) MATCH(nodeTo %s %s) CREATE (nodeFrom)-[:%s]->(nodeTo)";
         if (!relationship.getLabelFrom().isEmpty()) {
             relationship.setLabelFrom(": " + relationship.getLabelFrom());
         }
@@ -38,11 +38,9 @@ public class Neo4jRepositoryImpl implements Neo4jRepository {
         }
         String preparedQuery = String.format(query,
                 relationship.getLabelFrom(),
-                relationship.getNodeFrom().getNames()[0],
-                relationship.getNodeFrom().getValues()[0],
+                relationship.getNodeFrom().toString(),
                 relationship.getLabelTo(),
-                relationship.getNodeTo().getNames()[0],
-                relationship.getNodeTo().getValues()[0],
+                relationship.getNodeTo().toString(),
                 type);
         neo4jClient.query(preparedQuery).fetch().all();
     }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/repository/postgres/PostgresRepository.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/repository/postgres/PostgresRepository.java
@@ -14,6 +14,8 @@ public interface PostgresRepository {
 
     Map<String, String> getColumnsInfo(String tableName);
 
+    String getColumnType(String tableName, String column);
+
     String getForeignColumnName(String tableName, String columnName);
 
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/repository/postgres/PostgresRepositoryImpl.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/repository/postgres/PostgresRepositoryImpl.java
@@ -5,7 +5,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @Repository
@@ -55,7 +56,7 @@ public class PostgresRepositoryImpl implements PostgresRepository {
                 AND table_name   = '%s';
                 """;
         String formattedQuery = String.format(query, getSchemaName(), tableName);
-        Map<String, String> columnsInfo = new HashMap<>();
+        Map<String, String> columnsInfo = new LinkedHashMap<>();
         jdbcTemplate.query(formattedQuery, (rs, rowNum) -> {
             String columnName = rs.getString("column_name");
             String columnType = rs.getString("data_type");
@@ -63,6 +64,21 @@ public class PostgresRepositoryImpl implements PostgresRepository {
             return columnsInfo;
         });
         return columnsInfo;
+    }
+
+    @Override
+    public String getColumnType(String tableName, String column) {
+        String query = """
+                SELECT data_type
+                FROM information_schema.columns
+                WHERE table_schema = '%s'
+                AND table_name   = '%s'
+                AND column_name = '%s';
+                """;
+        String formattedQuery = String.format(query, getSchemaName(), tableName, column);
+        List<String> type = jdbcTemplate.query(formattedQuery, (rs, rowNum) ->
+                rs.getString("data_type"));
+        return type.get(0);
     }
 
     @Override

--- a/src/main/resources/xml/schema.xsd
+++ b/src/main/resources/xml/schema.xsd
@@ -39,6 +39,7 @@
                         minOccurs="0"/>
             <xs:element name="renamedColumns" type="renamedColumnsType"
                         minOccurs="0"/>
+            <xs:element name="timeFormat" type="xs:string" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/src/main/resources/xml/script.xml
+++ b/src/main/resources/xml/script.xml
@@ -12,6 +12,7 @@
                             <newName>newName</newName>
                         </columns>
                     </renamedColumns>
+                    <timeFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timeFormat>
                 </configuration>
                 <labels>
                     <label>User</label>


### PR DESCRIPTION
close #12 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds functionality to handle Postgres types and format timestamps, as well as minor updates to improve code quality. 

### Detailed summary
- Added `getColumnType` method to `PostgresRepository` to handle Postgres types
- Added `timeFormat` property to `Node` class and `CSVNeo4jUploader` to format timestamps
- Updated `PostgresRepositoryImpl` to use `LinkedHashMap` instead of `HashMap`
- Updated `Node` class to handle Postgres types and format timestamps
- Updated `CSVNeo4jUploader` to handle `types` and `timeFormat` parameters

> The following files were skipped due to too many changes: `src/main/java/com/example/postgresneo4jmigrationtool/parser/XmlParser.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->