### PR TITLE
#26 Implement XML validation

### DIFF
--- a/.env
+++ b/.env
@@ -9,4 +9,6 @@ NEO4J_DATABASE=testneo4j
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=password
 
+XML_VALIDATION_ENABLED=true
 XML_CONFIG_LOCATION=src/main/resources/xml/script.xml
+XSD_SCHEMA_LOCATION=src/main/resources/xml/schema.xsd

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ User can:
 Here is an example of XML configuration file for node and relationship
 migration.
 
-You can validate your schema with `schema.xsd`schema.
+You can validate your schema with default `schema.xsd` schema. You need to
+pass `XML_VALIDATION_ENABLED` property as `true`.
 
 ```
 <migration>

--- a/src/main/java/com/example/postgresneo4jmigrationtool/PostgresNeo4jMigrationToolApplication.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/PostgresNeo4jMigrationToolApplication.java
@@ -2,6 +2,7 @@ package com.example.postgresneo4jmigrationtool;
 
 import com.example.postgresneo4jmigrationtool.parser.Parser;
 import com.example.postgresneo4jmigrationtool.parser.XmlParser;
+import com.example.postgresneo4jmigrationtool.parser.validator.XmlValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -14,8 +15,11 @@ public class PostgresNeo4jMigrationToolApplication {
     public static void main(String[] args) {
         ConfigurableApplicationContext appContext = SpringApplication.run(PostgresNeo4jMigrationToolApplication.class, args);
         try {
-            Parser parser = appContext.getBean(XmlParser.class);
-            parser.parse();
+            XmlValidator validator = appContext.getBean(XmlValidator.class);
+            if (validator.isValid()) {
+                Parser parser = appContext.getBean(XmlParser.class);
+                parser.parse();
+            }
         } catch (Exception e) {
             System.out.println(e.getMessage());
         }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/config/ApplicationConfig.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/config/ApplicationConfig.java
@@ -1,7 +1,10 @@
 package com.example.postgresneo4jmigrationtool.config;
 
+import com.example.postgresneo4jmigrationtool.parser.validator.XmlValidator;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import com.jcabi.xml.XSD;
+import com.jcabi.xml.XSDDocument;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,10 +18,31 @@ public class ApplicationConfig {
     @Value("${xml.script.path}")
     private String xmlPath;
 
+    @Value("${xml.validation.schema.path}")
+    private String xsdPath;
+
+    @Value("${xml.validation.enabled}")
+    private boolean validate;
+
     @SneakyThrows
     @Bean
     public XML xml() {
         return new XMLDocument(new File(xmlPath));
+    }
+
+    @SneakyThrows
+    @Bean
+    public XSD xsd() {
+        return new XSDDocument(new File(xsdPath));
+    }
+
+    @Bean
+    public XmlValidator xmlValidator(XML xml, XSD xsd) {
+        XmlValidator validator = new XmlValidator(xml, xsd);
+        if (validate) {
+            validator.validate();
+        }
+        return validator;
     }
 
 }

--- a/src/main/java/com/example/postgresneo4jmigrationtool/parser/validator/Validator.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/parser/validator/Validator.java
@@ -1,0 +1,7 @@
+package com.example.postgresneo4jmigrationtool.parser.validator;
+
+public interface Validator {
+
+    void validate();
+
+}

--- a/src/main/java/com/example/postgresneo4jmigrationtool/parser/validator/XmlValidator.java
+++ b/src/main/java/com/example/postgresneo4jmigrationtool/parser/validator/XmlValidator.java
@@ -1,0 +1,35 @@
+package com.example.postgresneo4jmigrationtool.parser.validator;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XSD;
+import lombok.Data;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.transform.stream.StreamSource;
+import java.io.StringReader;
+import java.util.Collection;
+
+@Data
+public class XmlValidator implements Validator {
+
+    private final XML xml;
+    private final XSD xsd;
+    private boolean valid = true;
+
+    @Override
+    public void validate() {
+        Collection<SAXParseException> errors = xsd.validate(
+                new StreamSource(new StringReader(xml.toString()))
+        );
+        if (!errors.isEmpty()) {
+            System.out.println("VALIDATION FAILED");
+            for (SAXParseException e : errors) {
+                System.out.println(e.toString());
+            }
+            valid = false;
+        } else {
+            valid = true;
+        }
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,6 +27,10 @@ logging:
     root: OFF
 
 xml:
+  validation:
+    enabled: ${XML_VALIDATION_ENABLED}
+    schema:
+      path: ${XSD_SCHEMA_LOCATION}
   delimiter: ;
   script:
     path: ${XML_CONFIG_LOCATION}


### PR DESCRIPTION
close #26 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds XML validation to the migration tool. It introduces a `Validator` interface, an `XmlValidator` class, and adds configuration options for enabling validation and specifying the schema location.

### Detailed summary
- Adds `Validator` interface for schema validation
- Adds `XmlValidator` class for XML validation
- Adds configuration options for XML validation
- Adds `xsd` bean to `ApplicationConfig`
- Adds `xmlValidator` bean to `ApplicationConfig` for XML validation
- Modifies `PostgresNeo4jMigrationToolApplication` to use `XmlValidator` before parsing XML file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->